### PR TITLE
operatorの戻り値からのプロパティ

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -687,7 +687,7 @@ class B2PMXEM_PT_PosePanel(bpy.types.Panel):
             "b2pmxe.mute_ik",
             text="",
             icon="HIDE_OFF" if mute_type == True else "HIDE_ON"
-        )#.flag = mute_type
+        ).flag = mute_type
 
         # Display
         obj = context.object


### PR DESCRIPTION
fix #7

いつの間にか起きなくなってたので、コメントアウトをもとに戻す。

原因はよく分からん。

該当箇所の書き方は正しいようなので、それで。