### PR TITLE
ボーンモーフ対応

### DIFF
--- a/export_pmx.py
+++ b/export_pmx.py
@@ -341,10 +341,11 @@ def create_material_PMMorphOffset(xml_morph_offset: XMLMaterialMorphOffset, mat_
     return offset
 
 
-def create_material_PMMorph(xml_morph: XMLMorph,  mat_name_list: List[str]) -> pmx.PMMorph:
+def create_material_morph_dict(xml_morph_list: Dict[str, XMLMorph],
+                               mat_name_list: List[str]) -> Dict[str, pmx.PMMorph]:
 
-    def filter_map() -> Generator[pmx.PMMorphOffset, None, None]:
-        for offset in xml_morph.offsets:
+    def converter(offsets) -> Generator[pmx.PMMorphOffset, None, None]:
+        for offset in offsets:
             if offset.material_name is not None:
                 for i, name in enumerate(mat_name_list):
                     if offset.material_name == name:
@@ -353,23 +354,7 @@ def create_material_PMMorph(xml_morph: XMLMorph,  mat_name_list: List[str]) -> p
             else:
                 yield create_material_PMMorphOffset(offset, -1)
 
-    pm_morph = pmx.PMMorph()
-    pm_morph.Name = xml_morph.name
-    pm_morph.Name_E = xml_morph.name_e
-    pm_morph.Panel = xml_morph.group
-    pm_morph.Type = 8
-    pm_morph.Offsets = [o for o in filter_map()]
-    return pm_morph
-
-
-def create_material_morph_dict(xml_morph_list: Dict[str, XMLMorph],
-                               mat_name_list: List[str]) -> Dict[str, pmx.PMMorph]:
-    def filter_map() -> Generator[Tuple[str, pmx.PMMorph], None, None]:
-        for k, v in xml_morph_list.items():
-            if v.type == 8:
-                yield k, create_material_PMMorph(v, mat_name_list)
-
-    return {k: v for k, v in filter_map()}
+    return create_PMMorph_dict(xml_morph_list, 8, converter)
 
 
 def create_PMJoint(joint, rigid_index: Dict[str, int]) -> pmx.PMJoint:

--- a/import_pmx.py
+++ b/import_pmx.py
@@ -1039,33 +1039,7 @@ def make_xml_morphs(list: Iterable[XMLMorph]) -> etree.Element:
 
     for morph in list:
         if morph.type == 8:
-            builder.start_with_obj("morph", morph)
-            builder.new_line()
-
-            builder.data("  ")
-            builder.start("material_offsets")
-            builder.new_line()
-            for offset in morph.offsets:
-                builder.data("    ")
-                builder.start_with_obj("material_offset", offset)
-                builder.new_line()
-                make_xml_self_closing_with_obj(builder, "mat_diffuse", offset.diffuse, 3)
-                make_xml_self_closing_with_obj(builder, "mat_speculer", offset.speculer, 3)
-                make_xml_self_closing_with_obj(builder, "mat_ambient", offset.ambient, 3)
-                make_xml_self_closing_with_obj(builder, "mat_edge_color", offset.edge_color, 3)
-                make_xml_self_closing_with_obj(builder, "mat_texture", offset.texture, 3)
-                make_xml_self_closing_with_obj(builder, "mat_sphere", offset.sphere, 3)
-                make_xml_self_closing_with_obj(builder, "mat_toon", offset.toon, 3)
-                builder.data("    ")
-                builder.end("material_offset")
-                builder.new_line()
-
-            builder.data("  ")
-            builder.end("material_offsets")
-            builder.new_line()
-
-            builder.end("morph")
-            builder.new_line()
+            make_xml_material_morph(builder, morph)
         else:
             make_xml_self_closing_with_obj(builder, "morph", morph, 0)
 
@@ -1078,6 +1052,42 @@ def make_xml_morphs(list: Iterable[XMLMorph]) -> etree.Element:
     morphs_elm.insert(0, morph_comment)
 
     return morphs_elm
+
+
+def make_xml_material_morph(builder: UtilTreeBuilder, morph: XMLMorph):
+    builder.start_with_obj("morph", morph)
+    builder.new_line()
+
+    builder.data("  ")
+    builder.start("material_offsets")
+    builder.new_line()
+    for offset in morph.offsets:
+        make_xml_material_morph_offset(builder, offset, 2)
+
+    builder.data("  ")
+    builder.end("material_offsets")
+    builder.new_line()
+
+    builder.end("morph")
+    builder.new_line()
+
+
+def make_xml_material_morph_offset(builder: UtilTreeBuilder,
+                                   offset: XMLMaterialMorphOffset,
+                                   indent_level: int):
+    builder.data("  " * indent_level)
+    builder.start_with_obj("material_offset", offset)
+    builder.new_line()
+    make_xml_self_closing_with_obj(builder, "mat_diffuse", offset.diffuse, indent_level + 1)
+    make_xml_self_closing_with_obj(builder, "mat_speculer", offset.speculer, indent_level + 1)
+    make_xml_self_closing_with_obj(builder, "mat_ambient", offset.ambient, indent_level + 1)
+    make_xml_self_closing_with_obj(builder, "mat_edge_color", offset.edge_color, indent_level + 1)
+    make_xml_self_closing_with_obj(builder, "mat_texture", offset.texture, indent_level + 1)
+    make_xml_self_closing_with_obj(builder, "mat_sphere", offset.sphere, indent_level + 1)
+    make_xml_self_closing_with_obj(builder, "mat_toon", offset.toon, indent_level + 1)
+    builder.data("  " * indent_level)
+    builder.end("material_offset")
+    builder.new_line()
 
 
 def convert_material(src: Iterable[PMMaterial],

--- a/import_pmx.py
+++ b/import_pmx.py
@@ -18,6 +18,9 @@ from .pmx import PMMaterial
 from .pmx import PMTexture
 from .pmx import PMMorphOffset
 from .supplement_xml.supplement_xml import Morph as XMLMorph
+from .supplement_xml.supplement_xml import Move as XMLMove
+from .supplement_xml.supplement_xml import Rotate as XMLRotate
+from .supplement_xml.supplement_xml import BoneMorphOffset as XMLBoneMorphOffset
 from .supplement_xml.supplement_xml import Material as XMLMaterial
 from .supplement_xml.supplement_xml import EdgeColor as XMLEdgeColor
 from .supplement_xml.supplement_xml import Diffuse as XMLDiffuse
@@ -33,6 +36,7 @@ from typing import List
 from typing import Dict
 from typing import Iterable
 from typing import Generator
+from typing import Tuple
 
 # global_variable
 GV = global_variable.Init()
@@ -766,6 +770,10 @@ def make_xml(pmx_data: pmx.Model, filepath, use_japanese_name, xml_save_versions
         mat_index: Get_JP_or_EN_Name(pmx_mat.Name, pmx_mat.Name_E, use_japanese_name)
         for (mat_index, pmx_mat) in enumerate(pmx_data.Materials)
     }
+    blender_bone_list = {
+        bone_index: Get_JP_or_EN_Name(pmx_bone.Name, pmx_bone.Name_E, use_japanese_name, bone_mode=True)
+        for (bone_index, pmx_bone) in enumerate(pmx_data.Bones)
+    }
 
     #
     # XML
@@ -786,7 +794,7 @@ def make_xml(pmx_data: pmx.Model, filepath, use_japanese_name, xml_save_versions
     #
     # Morphs
     #
-    morph_list = convert_morph(pmx_data.Morphs, blender_morph_list, blender_mat_list)
+    morph_list = convert_morph(pmx_data.Morphs, blender_morph_list, blender_mat_list, blender_bone_list)
     morph_root = make_xml_morphs(morph_list)
     morph_root.tail = "\n"
     root.append(morph_root)
@@ -797,12 +805,6 @@ def make_xml(pmx_data: pmx.Model, filepath, use_japanese_name, xml_save_versions
     bone_root = etree.SubElement(root, "bones")
     bone_root.text = "\n"
     bone_root.tail = "\n"
-
-    blender_bone_list = {}
-
-    for (bone_index, pmx_bone) in enumerate(pmx_data.Bones):
-        blender_bone_name = Get_JP_or_EN_Name(pmx_bone.Name, pmx_bone.Name_E, use_japanese_name, bone_mode=True)
-        blender_bone_list[bone_index] = (blender_bone_name)
 
     for (bone_index, pmx_bone) in enumerate(pmx_data.Bones):
         blender_bone_name = blender_bone_list[bone_index]
@@ -983,7 +985,8 @@ def make_xml_pmdinfo(pmx_data: pmx.Model) -> etree.Element:
 
 def convert_morph(src: Iterable[PMMorph],
                   index_dict: Dict[int, str],
-                  mat_index_dict: Dict[int, str]) -> Generator[XMLMorph, None, None]:
+                  mat_index_dict: Dict[int, str],
+                  bone_index_dict: Dict[int, str]) -> Generator[XMLMorph, None, None]:
     # Morph
     # Name    # morph name
     # Name_E  # morph name English
@@ -1001,10 +1004,33 @@ def convert_morph(src: Iterable[PMMorph],
         morph.b_name = blender_morph_name
         morph.type = pmx_morph.Type
 
-        if pmx_morph.Type == 8:
+        if pmx_morph.Type == 2:
+            morph.offsets = convert_bone_morph(pmx_morph.Offsets, bone_index_dict)
+        elif pmx_morph.Type == 8:
             morph.offsets = convert_material_morph(pmx_morph.Offsets, mat_index_dict)
 
         yield morph
+
+
+# PMX Editor の表示に合わせた クォータニオン → オイラー角変換
+def pmx_quat2euler(vector: mathutils.Vector) -> Tuple[float, float, float]:
+    rotate_quat = mathutils.Quaternion(vector.wxyz)
+    rotate_euler = rotate_quat.to_euler("ZXY")
+    return (math.degrees(rotate_euler.x),
+            math.degrees(rotate_euler.y),
+            math.degrees(rotate_euler.z))
+
+
+def convert_bone_morph(src: Iterable[PMMorphOffset],
+                       bone_index_dict: Dict[int, str]) -> Generator[XMLBoneMorphOffset, None, None]:
+    for pmx_offset in src:
+        rotate_euler = pmx_quat2euler(pmx_offset.Rotate)
+
+        offset = XMLBoneMorphOffset()
+        offset.bone_name = bone_index_dict[pmx_offset.Index]
+        offset.move = XMLMove(*(pmx_offset.Move.to_tuple()))
+        offset.rotate = XMLRotate(*rotate_euler)
+        yield offset
 
 
 def as_RGBADiff(color: mathutils.Vector) -> XMLRGBADiff:
@@ -1038,7 +1064,9 @@ def make_xml_morphs(list: Iterable[XMLMorph]) -> etree.Element:
     builder.start("morphs", {})
 
     for morph in list:
-        if morph.type == 8:
+        if morph.type == 2:
+            make_xml_bone_morph(builder, morph)
+        elif morph.type == 8:
             make_xml_material_morph(builder, morph)
         else:
             make_xml_self_closing_with_obj(builder, "morph", morph, 0)
@@ -1052,6 +1080,38 @@ def make_xml_morphs(list: Iterable[XMLMorph]) -> etree.Element:
     morphs_elm.insert(0, morph_comment)
 
     return morphs_elm
+
+
+def make_xml_bone_morph(builder: UtilTreeBuilder, morph: XMLMorph):
+    builder.start_with_obj("morph", morph)
+    builder.new_line()
+
+    builder.data("  ")
+    builder.start("bone_offsets")
+    builder.new_line()
+    for offset in morph.offsets:
+        make_xml_bone_morph_offset(builder, offset, 2)
+
+    builder.data("  ")
+    builder.end("bone_offsets")
+    builder.new_line()
+
+    builder.end("morph")
+    builder.new_line()
+
+
+def make_xml_bone_morph_offset(builder: UtilTreeBuilder,
+                               offset: XMLBoneMorphOffset,
+                               indent_level: int):
+
+    builder.data("  " * indent_level)
+    builder.start_with_obj("bone_offset", offset)
+    builder.new_line()
+    make_xml_self_closing_with_obj(builder, "bone_move", offset.move, indent_level + 1)
+    make_xml_self_closing_with_obj(builder, "bone_rotate", offset.rotate, indent_level + 1)
+    builder.data("  " * indent_level)
+    builder.end("bone_offset")
+    builder.new_line()
 
 
 def make_xml_material_morph(builder: UtilTreeBuilder, morph: XMLMorph):

--- a/supplement_xml/supplement_xml.py
+++ b/supplement_xml/supplement_xml.py
@@ -134,6 +134,29 @@ class MaterialMorphOffset:
     toon: RGBADiff = RGBADiff()
 
 
+@dataclass
+class Move:
+    x: float = 0.0
+    y: float = 0.0
+    z: float = 0.0
+
+
+@dataclass
+class Rotate:
+    x: float = 0.0
+    y: float = 0.0
+    z: float = 0.0
+
+
+class BoneMorphOffset:
+    bone_name: str
+    move: Move = Move()
+    rotate: Rotate = Rotate()
+
+
+MorphOffsets = Union[Iterable[MaterialMorphOffset], Iterable[BoneMorphOffset]]
+
+
 class Morph:
     group: int = 4
     name: Optional[str]
@@ -141,4 +164,4 @@ class Morph:
     b_name: str
     type: int = 1
 
-    offsets: Iterable[MaterialMorphOffset] = []
+    offsets: MorphOffsets = []

--- a/supplement_xml/supplement_xml_reader.py
+++ b/supplement_xml/supplement_xml_reader.py
@@ -138,7 +138,9 @@ class SupplementXmlReader:
 
             for xml_index, morph_elm in enumerate(morph_l):
                 morph = supplement_xml.elm_to_obj(morph_elm, supplement_xml.Morph)
-                if morph.type == 8:
+                if morph.type == 2:
+                    morph.offsets = self.bone_morph_offset(morph_elm)
+                elif morph.type == 8:
                     morph.offsets = self.material_morph_offset(morph_elm)
 
                 b_name = morph.b_name
@@ -147,6 +149,23 @@ class SupplementXmlReader:
                     xml_morph_list[b_name] = morph
 
         return (xml_morph_index, xml_morph_list)
+
+    def bone_morph_offset(self, elm: Element) -> Generator[supplement_xml.BoneMorphOffset, None, None]:
+
+        for offset_elm in elm.findall('bone_offsets/bone_offset'):
+
+            def read_child(child_name, klass):
+                child = offset_elm.find(child_name)
+                if child is None:
+                    return klass()
+                else:
+                    return supplement_xml.elm_to_obj(child, klass)
+
+            offset = supplement_xml.elm_to_obj(offset_elm, supplement_xml.BoneMorphOffset)
+            offset.move = read_child('bone_move', supplement_xml.Move)
+            offset.rotate = read_child('bone_rotate', supplement_xml.Rotate)
+
+            yield offset
 
     def material_morph_offset(self, elm: Element) -> Generator[supplement_xml.MaterialMorphOffset, None, None]:
 

--- a/tests/test_supplement_xml_reader.py
+++ b/tests/test_supplement_xml_reader.py
@@ -310,6 +310,79 @@ class TestSupplementXmlReader(unittest.TestCase):
         with self.assertRaises(StopIteration):
             next(iter_m_C)
 
+    def test_morph_bone_offset(self):
+        file_name = 'test.pmx'
+        file_path = os.path.join(self.test_dir, file_name)
+        xml_file_path = os.path.join(self.test_dir, 'test.xml')
+
+        with open(xml_file_path, 'w') as fp:
+            test_content = """
+            <ns0:pmxstatus xmlns:ns0="local" xml:lang="jp">
+            <morphs>
+            <morph b_name="A" group="1" name="A" name_e="A" />
+            <morph b_name="B" group="2" name="B" name_e="I" type="2">
+            <bone_offsets>
+            <bone_offset bone_name="aaa">
+            <bone_move x="0.1" y="0.2" z="0.3" />
+            <bone_rotate x="0.4" y="0.5" z="0.6" />
+            </bone_offset>
+            <bone_offset bone_name="bbb">
+            <bone_move x="0.7" y="0.8" z="0.9" />
+            <bone_rotate x="1.0" y="1.1" z="1.2" />
+            </bone_offset>
+            </bone_offsets>
+            </morph>
+            <morph b_name="C" group="3" name="C" name_e="U" type="2">
+            <bone_offsets>
+            <bone_offset bone_name="ccc">
+            <bone_move x="0.0" y="0.0" z="0.0" />
+            <bone_rotate x="0.0" y="0.0" z="0.0" />
+            </bone_offset>
+            <bone_offset bone_name="ddd">
+            </bone_offset>
+            </bone_offsets>
+            </morph>
+            </morphs>
+            </ns0:pmxstatus>
+            """
+            fp.write(test_content)
+
+        reader = SupplementXmlReader(file_name, file_path, True)
+        index_dict, element_dict = reader.morph()
+
+        m_A = element_dict['A']
+        m_B = element_dict['B']
+        m_C = element_dict['C']
+
+        self.assertEqual(m_A.type, 1)
+        self.assertEqual(len(m_A.offsets), 0)
+
+        iter_m_B = iter(m_B.offsets)
+        offset = next(iter_m_B)
+        self.assertEqual(m_B.type, 2)
+        self.assertEqual(offset.bone_name, "aaa")
+        self.assertEqual(astuple(offset.move), (0.1, 0.2, 0.3))
+        self.assertEqual(astuple(offset.rotate), (0.4, 0.5, 0.6))
+        offset = next(iter_m_B)
+        self.assertEqual(offset.bone_name, "bbb")
+        self.assertEqual(astuple(offset.move), (0.7, 0.8, 0.9))
+        self.assertEqual(astuple(offset.rotate), (1.0, 1.1, 1.2))
+        with self.assertRaises(StopIteration):
+            next(iter_m_B)
+
+        iter_m_C = iter(m_C.offsets)
+        offset = next(iter_m_C)
+        self.assertEqual(m_C.type, 2)
+        self.assertEqual(offset.bone_name, "ccc")
+        self.assertEqual(astuple(offset.move), (0.0, 0.0, 0.0))
+        self.assertEqual(astuple(offset.rotate), (0.0, 0.0, 0.0))
+        offset = next(iter_m_C)
+        self.assertEqual(offset.bone_name, "ddd")
+        self.assertEqual(astuple(offset.move), (0.0, 0.0, 0.0))
+        self.assertEqual(astuple(offset.rotate), (0.0, 0.0, 0.0))
+        with self.assertRaises(StopIteration):
+            next(iter_m_C)
+
     def test_label(self):
         file_name = 'test.pmx'
         file_path = os.path.join(self.test_dir, file_name)


### PR DESCRIPTION
ボーンモーフのパラメータをXMLに保存・復帰する一連の処理

ボーンモーフの回転量の値は、PMX上はクォータニオンで保存されているが、XML上ではオイラー角で保存する
* PMX Editor上はオイラー角で表示されている
* XMLを直接書き換えるときに、クォータニオンの4つの値が満たすべき制約を満たさせるのが難しい

#37