### PR TITLE
使わなくなった戻り値を削除

### DIFF
--- a/export_pmx.py
+++ b/export_pmx.py
@@ -795,7 +795,7 @@ def write_pmx_data(context, filepath="",
         morph_list = {}
 
         # read default_xml data
-        xml_morph_index, xml_morph_list = xml_reader.morph()
+        xml_morph_list = xml_reader.morph()
 
         # Vertex
         # print("Get Vertex")

--- a/supplement_xml/supplement_xml_reader.py
+++ b/supplement_xml/supplement_xml_reader.py
@@ -117,20 +117,9 @@ class SupplementXmlReader:
         else:
             return supplement_xml.elm_to_obj(child, klass)
 
-    def morph(self) -> Tuple[Dict[int, str], Dict[str, supplement_xml.Morph]]:
+    def morph(self) -> Dict[str, supplement_xml.Morph]:
 
-        xml_morph_index = {}
         xml_morph_list = {}
-
-        if self.def_root is not None:
-            morph_root = self.def_root.find("morphs")
-            morph_l = morph_root.findall("morph") if morph_root else []
-
-            for morph_elm in morph_l:
-                morph = supplement_xml.elm_to_obj(morph_elm, supplement_xml.Morph)
-                b_name = morph.b_name
-                if b_name is not None:
-                    xml_morph_list[b_name] = morph
 
         if self.xml_root is not None:
             morph_root = self.xml_root.find("morphs")
@@ -147,10 +136,19 @@ class SupplementXmlReader:
 
                 b_name = morph.b_name
                 if b_name is not None:
-                    xml_morph_index[xml_index] = b_name
                     xml_morph_list[b_name] = morph
 
-        return (xml_morph_index, xml_morph_list)
+        if self.def_root is not None:
+            morph_root = self.def_root.find("morphs")
+            morph_l = morph_root.findall("morph") if morph_root else []
+
+            for morph_elm in morph_l:
+                morph = supplement_xml.elm_to_obj(morph_elm, supplement_xml.Morph)
+                b_name = morph.b_name
+                if b_name is not None and b_name not in xml_morph_list:
+                    xml_morph_list[b_name] = morph
+
+        return xml_morph_list
 
     def group_morph_offset(self, elm: Element) -> Generator[supplement_xml.GroupMorphOffset, None, None]:
 

--- a/tests/test_supplement_xml_reader.py
+++ b/tests/test_supplement_xml_reader.py
@@ -156,15 +156,16 @@ class TestSupplementXmlReader(unittest.TestCase):
             fp.write(test_content)
 
         reader = SupplementXmlReader(file_name, file_path, True)
-        index_dict, element_dict = reader.morph()
+        element_dict = reader.morph()
+        index_order = list(element_dict.keys())
 
-        self.assertEqual(index_dict[0], 'あ')
-        self.assertEqual(index_dict[1], 'い')
-        self.assertEqual(index_dict[2], 'う')
-        self.assertEqual(index_dict[3], 'え')
-        self.assertEqual(index_dict[4], 'お')
-        self.assertEqual(index_dict[5], 'にやり')
-        self.assertEqual(index_dict[6], '困る')
+        self.assertEqual(index_order[0], 'あ')
+        self.assertEqual(index_order[1], 'い')
+        self.assertEqual(index_order[2], 'う')
+        self.assertEqual(index_order[3], 'え')
+        self.assertEqual(index_order[4], 'お')
+        self.assertEqual(index_order[5], 'にやり')
+        self.assertEqual(index_order[6], '困る')
         self.assertEqual(element_dict['あ'].b_name, 'あ')
         self.assertEqual(element_dict['い'].b_name, 'い')
         self.assertEqual(element_dict['う'].b_name, 'う')
@@ -238,7 +239,7 @@ class TestSupplementXmlReader(unittest.TestCase):
             fp.write(test_content)
 
         reader = SupplementXmlReader(file_name, file_path, True)
-        index_dict, element_dict = reader.morph()
+        element_dict = reader.morph()
 
         m_A = element_dict['A']
         m_B = element_dict['B']
@@ -348,7 +349,7 @@ class TestSupplementXmlReader(unittest.TestCase):
             fp.write(test_content)
 
         reader = SupplementXmlReader(file_name, file_path, True)
-        index_dict, element_dict = reader.morph()
+        element_dict = reader.morph()
 
         m_A = element_dict['A']
         m_B = element_dict['B']
@@ -411,7 +412,7 @@ class TestSupplementXmlReader(unittest.TestCase):
             fp.write(test_content)
 
         reader = SupplementXmlReader(file_name, file_path, True)
-        index_dict, element_dict = reader.morph()
+        element_dict = reader.morph()
 
         m_A = element_dict['A']
         m_B = element_dict['B']


### PR DESCRIPTION
Python3.7からDictが順番を保存するようになったんで