### PR TITLE
XMLに書き出す小数の桁数を調整

### DIFF
--- a/supplement_xml/supplement_xml.py
+++ b/supplement_xml/supplement_xml.py
@@ -50,7 +50,10 @@ def obj_to_elm(obj: Type[T], element: Element):
             continue
         val = getattr(obj, k)
         if val is not None:
-            element.set(k, str(val))
+            if v in [float, Union[float, None]]:
+                element.set(k, f'{val:.8}')
+            else:
+                element.set(k, str(val))
 
 
 class EdgeColor:


### PR DESCRIPTION
共通処理のところ。

PMXは単精度なんであんまり長い桁出力しても仕方ない。

10進だと約7.225 桁( [Wikipedia 単精度浮動小数点数](https://ja.wikipedia.org/wiki/%E5%8D%98%E7%B2%BE%E5%BA%A6%E6%B5%AE%E5%8B%95%E5%B0%8F%E6%95%B0%E7%82%B9%E6%95%B0) )なので8桁出しておく
