### PR TITLE
bl_infoにdoc_url追加

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -29,6 +29,7 @@ bl_info = {
     "warning": "",
     "wiki_url": "https://github.com/matunnkazumi/blender2pmxem/wiki",
     "tracker_url": "https://github.com/matunnkazumi/blender2pmxem/issues",
+    "doc_url": "https://blender2pmxem.netlify.app/",
     "category": "Import-Export"
 }
 


### PR DESCRIPTION
これ
https://wiki.blender.jp/Dev:JA/Ref/Release_Notes/2.83/Python_API

wiki_urlの削除は今回はしない