### PR TITLE
CIの Python のバージョンを3.10にする

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -22,7 +22,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.7.x'
+          python-version: '3.10.x'
           architecture: 'x64'
       - name: install lint tools
         run: pip install flake8==3.7.9 mypy==0.790

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -22,7 +22,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.7.x'
+          python-version: '3.10.x'
           architecture: 'x64'
       - name: install required package
         run: pip install mathutils


### PR DESCRIPTION
mathutil がエラーになる都合で、古いPythonのバージョンを使っていたが、すでに解消されていたので Python のバージョンを上げる。

* https://gitlab.com/ideasman42/blender-mathutils/-/issues/27