### PR TITLE
MeshVertex.normal プロパティ 読み込み専用 対応

### DIFF
--- a/import_pmx.py
+++ b/import_pmx.py
@@ -544,7 +544,6 @@ def read_pmx_data(context, filepath="",
 
         for vert_index, vert_data in enumerate(pmx_data.Vertices):
             mesh.vertices[vert_index].co = GT(vert_data.Position, GlobalMatrix)
-            mesh.vertices[vert_index].normal = GT_normal(vert_data.Normal, GlobalMatrix)
             # mesh.vertices[vert_index].uv = pmx_data.Vertices[vert_index].UV
 
             # BDEF1


### PR DESCRIPTION
https://wiki.blender.jp/Dev:JA/Ref/Release_Notes/3.20/Python_API
「これは頂点の法線の計算方法がオンデマンドであり、混乱を防ぐためです」

随時再検索するから代入してもあまり意味がなかった模様